### PR TITLE
Fix/스토리 수정

### DIFF
--- a/module-api/src/main/java/com/junior/controller/CommentController.java
+++ b/module-api/src/main/java/com/junior/controller/CommentController.java
@@ -55,7 +55,7 @@ public class CommentController {
             @RequestParam("size") int size,
             @PathVariable("storyId") Long storyId
     ) {
-        Slice<ResponseParentCommentDto> parentCommentDto = commentService.findParentCommentByStoryId(storyId, cursorId, size);
+        Slice<ResponseParentCommentDto> parentCommentDto = commentService.findParentCommentByStoryId(userPrincipal, storyId, cursorId, size);
 
         return CommonResponse.success(StatusCode.COMMENT_READ_SUCCESS, parentCommentDto);
     }
@@ -67,7 +67,7 @@ public class CommentController {
             @RequestParam("size") int size,
             @PathVariable("parentCommentId") Long parentCommentId
     ) {
-        Slice<ResponseChildCommentDto> childCommentDto = commentService.findChildCommentByParentCommentId(parentCommentId, cursorId, size);
+        Slice<ResponseChildCommentDto> childCommentDto = commentService.findChildCommentByParentCommentId(userPrincipal, parentCommentId, cursorId, size);
 
         return CommonResponse.success(StatusCode.COMMENT_READ_SUCCESS, childCommentDto);
     }

--- a/module-api/src/main/java/com/junior/service/comment/CommentService.java
+++ b/module-api/src/main/java/com/junior/service/comment/CommentService.java
@@ -60,18 +60,22 @@ public class CommentService {
         notificationService.saveNotification(userPrincipal, findMember.getProfileImage(), comment.getContent(), findStory.getId(), NotificationType.COMMENT);
     }
 
-    public Slice<ResponseParentCommentDto> findParentCommentByStoryId(Long storyId, Long cursorId, int size) {
+    public Slice<ResponseParentCommentDto> findParentCommentByStoryId(UserPrincipal userPrincipal, Long storyId, Long cursorId, int size) {
+
+        Member member = userPrincipal.getMember();
 
         Pageable pageable = PageRequest.of(0, size);
 
-        return commentRepository.findParentCommentByStoryId(storyId, pageable, cursorId);
+        return commentRepository.findParentCommentByStoryId(member, storyId, pageable, cursorId);
     }
 
-    public Slice<ResponseChildCommentDto> findChildCommentByParentCommentId(Long parentCommentId, Long cursorId, int size) {
+    public Slice<ResponseChildCommentDto> findChildCommentByParentCommentId(UserPrincipal userPrincipal, Long parentCommentId, Long cursorId, int size) {
+
+        Member member = userPrincipal.getMember();
 
         Pageable pageable = PageRequest.of(0, size);
 
-        return commentRepository.findChildCommentByParentCommendId(parentCommentId, pageable, cursorId);
+        return commentRepository.findChildCommentByParentCommendId(member, parentCommentId, pageable, cursorId);
     }
 
     @Transactional

--- a/module-api/src/main/java/com/junior/service/story/MemberStoryService.java
+++ b/module-api/src/main/java/com/junior/service/story/MemberStoryService.java
@@ -45,11 +45,16 @@ public class MemberStoryService {
 
         Member findMember = userPrincipal.getMember();
 
-        Story findStory = storyRepository.findStoryByIdAndMember(storyId, findMember)
+        Story findStory = storyRepository.findById(storyId)
                 .orElseThrow(() -> new StoryNotFoundException(StatusCode.STORY_NOT_FOUND));
 
-        // 더티 체킹을 통해 수정쿼리가 자동으로 발생
-        findStory.updateStory(createStoryDto);
+        if(findMember.getId().equals(findStory.getMember().getId())) {
+            // 더티 체킹을 통해 수정쿼리가 자동으로 발생
+            findStory.updateStory(createStoryDto);
+        }
+        else {
+            throw new PermissionException(StatusCode.STORY_NOT_PERMISSION);
+        }
     }
 
     // findStoriesByMemberAndCityAndSearch

--- a/module-api/src/main/java/com/junior/service/story/MemberStoryService.java
+++ b/module-api/src/main/java/com/junior/service/story/MemberStoryService.java
@@ -93,15 +93,15 @@ public class MemberStoryService {
 
         Boolean isLikeStory = likeRepository.isLikeStory(findMember, findStory);
 
-        boolean isNotAuthor = findStory.isHidden() && !findStory.getMember().getId().equals(findMember.getId());
+        boolean isAuthor = findStory.isHidden() && findStory.getMember().getId().equals(findMember.getId());
 
-        if(isNotAuthor) {
+        if(!isAuthor) {
             throw new StoryNotFoundException(StatusCode.STORY_NOT_PERMISSION);
         }
 
         findStory.increaseViewCnt();
 
-        return ResponseStoryDto.from(findStory, isLikeStory);
+        return ResponseStoryDto.from(findStory, isLikeStory, isAuthor);
     }
 
     @Transactional

--- a/module-domain/src/main/java/com/junior/dto/comment/ResponseChildCommentDto.java
+++ b/module-domain/src/main/java/com/junior/dto/comment/ResponseChildCommentDto.java
@@ -10,7 +10,8 @@ public record ResponseChildCommentDto(
         Long memberId,
         String nickname,
         String profileImgPath,
-        LocalDateTime createDate
+        LocalDateTime createDate,
+        boolean isAuthor
 ) {
 
 }

--- a/module-domain/src/main/java/com/junior/dto/comment/ResponseParentCommentDto.java
+++ b/module-domain/src/main/java/com/junior/dto/comment/ResponseParentCommentDto.java
@@ -16,7 +16,8 @@ public record ResponseParentCommentDto(
         String nickname,
         String profileImgPath,
         Long childCount,
-        LocalDateTime createDate
+        LocalDateTime createDate,
+        boolean isAuthor
 ) {
 
 }

--- a/module-domain/src/main/java/com/junior/dto/story/ResponseStoryDto.java
+++ b/module-domain/src/main/java/com/junior/dto/story/ResponseStoryDto.java
@@ -18,6 +18,7 @@ public record ResponseStoryDto(
         String city,
         Long likeCnt,
         boolean isHidden,
+        boolean isAuthor,
         boolean isLikeStory,
         LocalDateTime createDate,
         List<String> imgUrls
@@ -38,7 +39,7 @@ public record ResponseStoryDto(
 //        this.imgUrls = imgUrls;
 //    }
 
-    public static ResponseStoryDto from(Story story, boolean isLikeStory) {
+    public static ResponseStoryDto from(Story story, boolean isLikeStory, boolean isAuthor) {
         return ResponseStoryDto.builder()
                 .id(story.getId())
                 .title(story.getTitle())
@@ -52,6 +53,7 @@ public record ResponseStoryDto(
                 .isLikeStory(isLikeStory)
                 .imgUrls(story.getImgUrls())
                 .createDate(story.getCreatedDate())
+                .isAuthor(isAuthor)
                 .build();
     }
 

--- a/module-domain/src/main/java/com/junior/repository/comment/CommentCustomRepository.java
+++ b/module-domain/src/main/java/com/junior/repository/comment/CommentCustomRepository.java
@@ -11,8 +11,8 @@ import java.util.List;
 
 public interface CommentCustomRepository {
 
-    public Slice<ResponseParentCommentDto> findParentCommentByStoryId(Long storyId, Pageable pageable, Long cursorId);
-    public Slice<ResponseChildCommentDto> findChildCommentByParentCommendId(Long parentCommentId, Pageable pageable, Long cursorId);
+    public Slice<ResponseParentCommentDto> findParentCommentByStoryId(Member member, Long storyId, Pageable pageable, Long cursorId);
+    public Slice<ResponseChildCommentDto> findChildCommentByParentCommendId(Member member, Long parentCommentId, Pageable pageable, Long cursorId);
 
     Slice<ResponseMyCommentDto> findCommentsByMember(Member findMember, Pageable pageable, Long cursorId);
 }

--- a/module-domain/src/main/java/com/junior/repository/comment/CommentCustomRepositoryImpl.java
+++ b/module-domain/src/main/java/com/junior/repository/comment/CommentCustomRepositoryImpl.java
@@ -47,7 +47,7 @@ public class CommentCustomRepositoryImpl implements CommentCustomRepository {
     }
 
     @Override
-    public Slice<ResponseParentCommentDto> findParentCommentByStoryId(Long storyId, Pageable pageable, Long cursorId) {
+    public Slice<ResponseParentCommentDto> findParentCommentByStoryId(Member member, Long storyId, Pageable pageable, Long cursorId) {
 
         BooleanBuilder booleanBuilder = new BooleanBuilder();
 
@@ -65,7 +65,8 @@ public class CommentCustomRepositoryImpl implements CommentCustomRepository {
                                 comment.member.nickname,
                                 comment.member.profileImage,
                                 comment.child.size().longValue(),
-                                comment.createdDate
+                                comment.createdDate,
+                                comment.member.eq(member)
                         )
                 )
                 .from(comment)
@@ -79,7 +80,7 @@ public class CommentCustomRepositoryImpl implements CommentCustomRepository {
     }
 
     @Override
-    public Slice<ResponseChildCommentDto> findChildCommentByParentCommendId(Long parentCommentId, Pageable pageable, Long cursorId) {
+    public Slice<ResponseChildCommentDto> findChildCommentByParentCommendId(Member member, Long parentCommentId, Pageable pageable, Long cursorId) {
 
         BooleanBuilder booleanBuilder = new BooleanBuilder();
         booleanBuilder.and(comment.parent.id.eq(parentCommentId));
@@ -94,7 +95,8 @@ public class CommentCustomRepositoryImpl implements CommentCustomRepository {
                                 comment.member.id,
                                 comment.member.nickname,
                                 comment.member.profileImage,
-                                comment.createdDate
+                                comment.createdDate,
+                                comment.member.eq(member)
                         )
                 )
                 .from(comment)

--- a/module-domain/src/main/java/com/junior/repository/story/custom/StoryCustomRepositoryImpl.java
+++ b/module-domain/src/main/java/com/junior/repository/story/custom/StoryCustomRepositoryImpl.java
@@ -264,7 +264,8 @@ public class StoryCustomRepositoryImpl implements StoryCustomRepository {
                         JPAExpressions.select(subStory.createdDate)
                                 .from(subStory)
                                 .where(
-                                        getDeleteCondition()
+                                        getDeleteCondition(),
+                                        story.isHidden.eq(false)
                                 )
                                 .orderBy(subStory.createdDate.desc())  // 최신 글 순으로 정렬
                                 .limit(100L) // 최신 n개의 글
@@ -287,7 +288,8 @@ public class StoryCustomRepositoryImpl implements StoryCustomRepository {
                 .from(story)
                 .where(getHiddenCondition(member),
                         eqCursorId(cursorId),
-                        getDeleteCondition()
+                        getDeleteCondition(),
+                        story.isHidden.eq(false)
                 )
                 .limit(pageable.getPageSize() + 1)
                 .orderBy(getOrderByClause("popular"))

--- a/module-domain/src/main/java/com/junior/repository/story/custom/StoryCustomRepositoryImpl.java
+++ b/module-domain/src/main/java/com/junior/repository/story/custom/StoryCustomRepositoryImpl.java
@@ -97,6 +97,14 @@ public class StoryCustomRepositoryImpl implements StoryCustomRepository {
         return hiddenCondition;
     }
 
+    private BooleanBuilder getIsAuthorCondition(Member member) {
+        BooleanBuilder isAuthorCondition = new BooleanBuilder();
+
+        isAuthorCondition.and(story.member.eq(member));
+
+        return isAuthorCondition;
+    }
+
     private BooleanBuilder getCityCondition(String city) {
         BooleanBuilder cityCondition = new BooleanBuilder();
 
@@ -155,7 +163,7 @@ public class StoryCustomRepositoryImpl implements StoryCustomRepository {
         Story stories = query.select(story)
                 .from(story)
                 .where(
-                        story.member.eq(member),
+                        getIsAuthorCondition(member),
                         story.id.eq(storyId),
                         getDeleteCondition()
                 )
@@ -177,6 +185,7 @@ public class StoryCustomRepositoryImpl implements StoryCustomRepository {
                                 Math.min(geoPointLt.longitude(), geoPointRb.longitude()),
                                 Math.max(geoPointLt.longitude(), geoPointRb.longitude())
                         ),
+                        getIsAuthorCondition(findMember),
                         getHiddenCondition(findMember),
                         getDeleteCondition()
                 )
@@ -189,7 +198,8 @@ public class StoryCustomRepositoryImpl implements StoryCustomRepository {
 
         List<ResponseStoryListDto> stories = query.select(createQResponseStoryListDto())
                 .from(story)
-                .where(story.member.eq(findMember),
+                .where(
+                        getIsAuthorCondition(findMember),
                         getCityCondition(city),
                         getSearchCondition(search),
                         eqCursorId(cursorId),
@@ -210,6 +220,7 @@ public class StoryCustomRepositoryImpl implements StoryCustomRepository {
 
         return query.select(new QResponseStoryCntByCityDto(story.city, story.count().intValue()))
                 .from(story)
+                .where(getIsAuthorCondition(findMember))
                 .groupBy(story.city)
                 .orderBy(story.city.asc())
                 .fetch();
@@ -231,7 +242,9 @@ public class StoryCustomRepositoryImpl implements StoryCustomRepository {
     public Optional<String> getRecommendedRandomCity() {
         String randomCity = query.select(story.city)
                 .from(story)
-                .where(getDeleteCondition())
+                .where(
+                        getDeleteCondition()
+                )
                 .orderBy(Expressions.numberTemplate(Double.class, "RAND()").asc())
                 .limit(1L)
                 .fetchOne();
@@ -250,7 +263,9 @@ public class StoryCustomRepositoryImpl implements StoryCustomRepository {
                 .where(story.createdDate.in(
                         JPAExpressions.select(subStory.createdDate)
                                 .from(subStory)
-                                .where(getDeleteCondition())
+                                .where(
+                                        getDeleteCondition()
+                                )
                                 .orderBy(subStory.createdDate.desc())  // 최신 글 순으로 정렬
                                 .limit(100L) // 최신 n개의 글
                 ))

--- a/module-domain/src/test/java/com/junior/repository/comment/CommentCustomRepositoryImplTest.java
+++ b/module-domain/src/test/java/com/junior/repository/comment/CommentCustomRepositoryImplTest.java
@@ -139,7 +139,7 @@ public class CommentCustomRepositoryImplTest {
 
         Pageable pageable = PageRequest.of(0, 5);
 
-        Slice<ResponseParentCommentDto> parentCommentByStoryId = commentRepository.findParentCommentByStoryId(story.getId(), pageable, null);
+        Slice<ResponseParentCommentDto> parentCommentByStoryId = commentRepository.findParentCommentByStoryId(testMember, story.getId(), pageable, null);
         List<ResponseParentCommentDto> content = parentCommentByStoryId.getContent();
 
         Assertions.assertThat(content.size()).isEqualTo(3);
@@ -204,7 +204,7 @@ public class CommentCustomRepositoryImplTest {
 
         Pageable pageable = PageRequest.of(0, 5);
 
-        Slice<ResponseChildCommentDto> parentCommentByStoryId = commentRepository.findChildCommentByParentCommendId(parentComment3.getId(), pageable, null);
+        Slice<ResponseChildCommentDto> parentCommentByStoryId = commentRepository.findChildCommentByParentCommendId(testMember, parentComment3.getId(), pageable, null);
         List<ResponseChildCommentDto> content = parentCommentByStoryId.getContent();
 
         Assertions.assertThat(content.size()).isEqualTo(3);


### PR DESCRIPTION
- 단일 스토리 반환 DTO에 저자 여부 추가
- 내가 작성한 스토리만 조회해야 하는데, 다른 사람 글까지 조회가 되는 버그 수정
- 추천 스토리 조회할 때 나만 보기 스토리는 조회가 안되도록 수정
- 댓글 반환할 때 저자 여부 추가
- 스토리 수정할 때 권한 밖의 글일 경우 권한 예외 반환하도록 수정