### PR TITLE
최근 인기있는 스토리 중복 조회 이슈

### DIFF
--- a/module-domain/src/main/java/com/junior/repository/story/custom/StoryCustomRepositoryImpl.java
+++ b/module-domain/src/main/java/com/junior/repository/story/custom/StoryCustomRepositoryImpl.java
@@ -67,6 +67,14 @@ public class StoryCustomRepositoryImpl implements StoryCustomRepository {
         return null;
     }
 
+    //FIXME: eqCursorId랑 하나로 합칠 예정
+    private BooleanExpression eqPopularityCursorId(Long cursorId, NumberExpression<Long> popularityScore) {
+        if (cursorId != null) {
+            return popularityScore.lt(cursorId);
+        }
+        return null;
+    }
+
     private OrderSpecifier<?> getPopularityOrder() {
         NumberExpression<Long> popularityScore = story.viewCnt.multiply(0.3)
                 .add(story.likeCnt.multiply(0.7));
@@ -284,10 +292,14 @@ public class StoryCustomRepositoryImpl implements StoryCustomRepository {
     @Override
     public Slice<ResponseStoryListDto> getRecentPopularStories(Member member, Long cursorId, Pageable pageable) {
 
+        // 인기 점수 계산
+        NumberExpression<Long> popularityScore = story.viewCnt.multiply(0.3)
+                .add(story.likeCnt.multiply(0.7));
+
         List<ResponseStoryListDto> stories = query.select(createQResponseStoryListDto())
                 .from(story)
                 .where(getHiddenCondition(member),
-                        eqCursorId(cursorId),
+                        eqPopularityCursorId(cursorId, popularityScore),
                         getDeleteCondition(),
                         story.isHidden.eq(false)
                 )


### PR DESCRIPTION
- eqCursorId 비교하는 로직이 인기순으로 정렬하는 로직이랑 달라서 2중으로 정렬되는 버그 수정