### PR TITLE
Fix/추천 스토리 권한 변경 119

### DIFF
--- a/module-api/src/main/java/com/junior/config/SecurityConfig.java
+++ b/module-api/src/main/java/com/junior/config/SecurityConfig.java
@@ -70,6 +70,10 @@ public class SecurityConfig {
                         .requestMatchers("/swagger-ui/**",
                                 "/swagger-resources/**",
                                 "/v3/api-docs/**").permitAll()
+                        // 단일 스토리 조회
+                        .requestMatchers("/api/v1/stories/{storyId}").permitAll()
+                        // public 스토리 리스트 조회
+                        .requestMatchers("/api/v1/public/stories/**").permitAll()
 
                         //admin 관련 설정
                         .requestMatchers("/api/v1/admin/**").hasRole(MemberRole.ADMIN.name())

--- a/module-api/src/main/java/com/junior/service/story/MemberStoryService.java
+++ b/module-api/src/main/java/com/junior/service/story/MemberStoryService.java
@@ -91,16 +91,18 @@ public class MemberStoryService {
         return storyRepository.findStoryByMap(findMember, geoPointLt, geoPointRb);
     }
 
-    @Transactional
+//    @Transactional
     public ResponseStoryDto findOneStory(UserPrincipal userPrincipal, Long storyId) {
-        Member findMember = userPrincipal.getMember();
+//        Member findMember = userPrincipal.getMember();
 
-        Story findStory = storyRepository.findById(storyId)
+        Member findMember = (userPrincipal != null) ? userPrincipal.getMember() : null;
+
+        Story findStory = storyRepository.findByIdAndIsDeletedFalse(storyId)
                 .orElseThrow(()->new StoryNotFoundException(StatusCode.STORY_NOT_FOUND));
 
-        Boolean isLikeStory = likeRepository.isLikeStory(findMember, findStory);
+        boolean isLikeStory = (findMember != null) && likeRepository.isLikeStory(findMember, findStory);
 
-        boolean isAuthor = findStory.getMember().getId().equals(findMember.getId());
+        boolean isAuthor = (findMember != null) && findStory.getMember().getId().equals(findMember.getId());
         boolean isHidden = findStory.isHidden();
 
         if(isHidden && !isAuthor) {

--- a/module-api/src/main/java/com/junior/service/story/PublicStoryService.java
+++ b/module-api/src/main/java/com/junior/service/story/PublicStoryService.java
@@ -24,7 +24,8 @@ public class PublicStoryService {
 
     public Slice<ResponseStoryListDto> findStoriesByFilter(UserPrincipal userPrincipal, Long cursorId, int size, String city, String search) {
 
-        Member member = userPrincipal.getMember();
+//        Member member = userPrincipal.getMember();
+        Member member = (userPrincipal != null) ? userPrincipal.getMember() : null;
 
         Pageable pageable = PageRequest.of(0, size);
 
@@ -45,7 +46,8 @@ public class PublicStoryService {
 
     public Slice<ResponseStoryListDto> getRecentPopularStories(UserPrincipal userPrincipal, Long cursorId, int size) {
 
-        Member member = userPrincipal.getMember();
+//        Member member = userPrincipal.getMember();
+        Member member = (userPrincipal != null) ? userPrincipal.getMember() : null;
 
         Pageable pageable = PageRequest.of(0, size);
 

--- a/module-domain/src/main/java/com/junior/repository/story/StoryRepository.java
+++ b/module-domain/src/main/java/com/junior/repository/story/StoryRepository.java
@@ -5,7 +5,9 @@ import com.junior.repository.story.custom.StoryCustomRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface StoryRepository extends JpaRepository<Story, Long>, StoryCustomRepository {
-
+    Optional<Story> findByIdAndIsDeletedFalse(Long id);
 }

--- a/module-domain/src/main/java/com/junior/repository/story/custom/StoryCustomRepositoryImpl.java
+++ b/module-domain/src/main/java/com/junior/repository/story/custom/StoryCustomRepositoryImpl.java
@@ -137,7 +137,7 @@ public class StoryCustomRepositoryImpl implements StoryCustomRepository {
                 .from(story)
                 .where(getCityCondition(city),
                         eqCursorId(cursorId),
-                        getHiddenCondition(member),
+//                        getHiddenCondition(member),
                         getSearchCondition(search),
                         getDeleteCondition()
                 )


### PR DESCRIPTION
- 단일 스토리 조회, public 스토리 조회 시 jwt 인증 안 하도록 설정
- 단일 스토리 조회 시 비회원도 볼 수 있도록 수정
- 비회원도 추천 스토리는 조회할 수 있도록 수정
- 전체 스토리 조회할 때 나만 보기 스토리는 제외