### PR TITLE
신고 관련 일부 기능 수정

### DIFF
--- a/module-api/src/main/java/com/junior/controller/report/ReportController.java
+++ b/module-api/src/main/java/com/junior/controller/report/ReportController.java
@@ -52,6 +52,7 @@ public class ReportController implements ReportApi {
         return ResponseEntity.status(StatusCode.REPORT_FIND_SUCCESS.getHttpCode()).body(CommonResponse.success(StatusCode.REPORT_FIND_SUCCESS, reportService.findReportTargetStoryDetail(reportId)));
     }
 
+    @Deprecated
     @PatchMapping("/api/v1/admin/reports/{report_id}/confirm")
     public ResponseEntity<CommonResponse<Object>> confirmReport(@PathVariable("report_id") Long reportId) {
         reportService.confirmReport(reportId);

--- a/module-api/src/main/java/com/junior/controller/report/ReportController.java
+++ b/module-api/src/main/java/com/junior/controller/report/ReportController.java
@@ -49,7 +49,7 @@ public class ReportController implements ReportApi {
      */
     @GetMapping("/api/v1/admin/reports/{report_id}/stories")
     public <T extends ReportDto> ResponseEntity<CommonResponse<AdminStoryDetailDto>> findReportTargetStoryDetail(@PathVariable(value = "report_id") Long reportId) {
-        return ResponseEntity.status(StatusCode.REPORT_FIND_SUCCESS.getHttpCode()).body(CommonResponse.success(StatusCode.REPORT_FIND_SUCCESS, reportService.findReportDetail(reportId)));
+        return ResponseEntity.status(StatusCode.REPORT_FIND_SUCCESS.getHttpCode()).body(CommonResponse.success(StatusCode.REPORT_FIND_SUCCESS, reportService.findReportTargetStoryDetail(reportId)));
     }
 
     @PatchMapping("/api/v1/admin/reports/{report_id}/confirm")

--- a/module-api/src/main/java/com/junior/controller/report/ReportController.java
+++ b/module-api/src/main/java/com/junior/controller/report/ReportController.java
@@ -3,6 +3,7 @@ package com.junior.controller.report;
 import com.junior.controller.api.ReportApi;
 import com.junior.dto.report.CreateReportDto;
 import com.junior.dto.report.ReportDto;
+import com.junior.dto.story.AdminStoryDetailDto;
 import com.junior.exception.StatusCode;
 import com.junior.page.PageCustom;
 import com.junior.response.CommonResponse;
@@ -38,6 +39,17 @@ public class ReportController implements ReportApi {
                                                                                           @RequestParam(name = "report_status", defaultValue = "ALL") String reportStatus) {
 
         return ResponseEntity.status(StatusCode.REPORT_FIND_SUCCESS.getHttpCode()).body(CommonResponse.success(StatusCode.REPORT_FIND_SUCCESS, reportService.findReport(reportStatus, pageable)));
+    }
+
+    /**
+     * 신고 내역 대상 스토리 상세 조회
+     * @param reportId 스토리 이름
+     * @return 스토리 세부내역 조회
+     * 해당 신고내역 확인 처리도 수행
+     */
+    @GetMapping("/api/v1/admin/reports/{report_id}/stories")
+    public <T extends ReportDto> ResponseEntity<CommonResponse<AdminStoryDetailDto>> findReportTargetStoryDetail(@PathVariable(value = "report_id") Long reportId) {
+        return ResponseEntity.status(StatusCode.REPORT_FIND_SUCCESS.getHttpCode()).body(CommonResponse.success(StatusCode.REPORT_FIND_SUCCESS, reportService.findReportDetail(reportId)));
     }
 
     @PatchMapping("/api/v1/admin/reports/{report_id}/confirm")

--- a/module-api/src/main/java/com/junior/service/report/ReportService.java
+++ b/module-api/src/main/java/com/junior/service/report/ReportService.java
@@ -8,6 +8,7 @@ import com.junior.domain.report.ReportType;
 import com.junior.domain.story.Comment;
 import com.junior.domain.story.Story;
 import com.junior.dto.report.*;
+import com.junior.dto.story.AdminStoryDetailDto;
 import com.junior.exception.*;
 import com.junior.page.PageCustom;
 import com.junior.repository.comment.CommentRepository;
@@ -136,6 +137,22 @@ public class ReportService {
                 .collect(Collectors.toList());
 
         return new PageCustom<>(result, report.getPageable(), report.getTotalElements());
+    }
+
+    @Transactional
+    public AdminStoryDetailDto findReportDetail(Long reportId){
+        Report report = reportRepository.findById(reportId)
+                .orElseThrow((() -> new ReportException(StatusCode.REPORT_NOT_FOUND)));
+
+        if (report.getReportType() != ReportType.STORY) {
+            throw new ReportException(StatusCode.REPORT_NOT_VALID);
+        }
+
+        report.confirmReport();
+
+        log.info("[{}] 신고 대상 스토리 상세 조회", Thread.currentThread().getStackTrace()[1].getMethodName());
+
+        return AdminStoryDetailDto.from(report.getStory());
     }
 
     @Transactional

--- a/module-api/src/main/java/com/junior/service/report/ReportService.java
+++ b/module-api/src/main/java/com/junior/service/report/ReportService.java
@@ -138,6 +138,7 @@ public class ReportService {
         return new PageCustom<>(result, report.getPageable(), report.getTotalElements());
     }
 
+    @Transactional
     public void confirmReport(Long id) {
 
         Report report = reportRepository.findById(id)
@@ -147,6 +148,7 @@ public class ReportService {
         report.confirmReport();
     }
 
+    @Transactional
     public void deleteReportTarget(Long id) {
 
         Report report = reportRepository.findById(id)

--- a/module-api/src/main/java/com/junior/service/report/ReportService.java
+++ b/module-api/src/main/java/com/junior/service/report/ReportService.java
@@ -144,6 +144,14 @@ public class ReportService {
         Report report = reportRepository.findById(id)
                 .orElseThrow(() -> new ReportException(StatusCode.REPORT_NOT_FOUND));
 
+        if (report.getReportStatus() == ReportStatus.CONFIRMED) {
+            throw new ReportException(StatusCode.REPORT_ALREADY_CONFIRMED);
+        } else if (report.getReportStatus() == ReportStatus.DELETED ||
+                (report.getReportType()==ReportType.STORY && report.getStory().getIsDeleted()) ||
+                (report.getReportType()==ReportType.COMMENT && report.getComment().getIsDeleted())) {
+            throw new ReportException(StatusCode.REPORT_TARGET_ALREADY_DELETED);
+        }
+
         log.info("[{}] 신고내역 확인 id: {}", Thread.currentThread().getStackTrace()[1].getMethodName(), report.getId());
         report.confirmReport();
     }
@@ -153,6 +161,14 @@ public class ReportService {
 
         Report report = reportRepository.findById(id)
                 .orElseThrow(() -> new ReportException(StatusCode.REPORT_NOT_FOUND));
+
+        if (report.getReportStatus() == ReportStatus.CONFIRMED) {
+            throw new ReportException(StatusCode.REPORT_ALREADY_CONFIRMED);
+        } else if (report.getReportStatus() == ReportStatus.DELETED ||
+                (report.getReportType()==ReportType.STORY && report.getStory().getIsDeleted()) ||
+                (report.getReportType()==ReportType.COMMENT && report.getComment().getIsDeleted())) {
+            throw new ReportException(StatusCode.REPORT_TARGET_ALREADY_DELETED);
+        }
 
         log.info("[{}] 신고대상 글 삭제 id: {}", Thread.currentThread().getStackTrace()[1].getMethodName(), report.getId());
         report.deleteReportTarget();

--- a/module-api/src/main/java/com/junior/service/report/ReportService.java
+++ b/module-api/src/main/java/com/junior/service/report/ReportService.java
@@ -140,7 +140,7 @@ public class ReportService {
     }
 
     @Transactional
-    public AdminStoryDetailDto findReportDetail(Long reportId){
+    public AdminStoryDetailDto findReportTargetStoryDetail(Long reportId){
         Report report = reportRepository.findById(reportId)
                 .orElseThrow((() -> new ReportException(StatusCode.REPORT_NOT_FOUND)));
 

--- a/module-api/src/main/java/com/junior/service/report/ReportService.java
+++ b/module-api/src/main/java/com/junior/service/report/ReportService.java
@@ -155,6 +155,7 @@ public class ReportService {
         return AdminStoryDetailDto.from(report.getStory());
     }
 
+    @Deprecated
     @Transactional
     public void confirmReport(Long id) {
 

--- a/module-api/src/test/java/com/junior/controller/report/ReportControllerTest.java
+++ b/module-api/src/test/java/com/junior/controller/report/ReportControllerTest.java
@@ -7,6 +7,7 @@ import com.junior.domain.report.ReportType;
 import com.junior.dto.report.CreateReportDto;
 import com.junior.dto.report.ReportDto;
 import com.junior.dto.report.StoryReportDto;
+import com.junior.dto.story.AdminStoryDetailDto;
 import com.junior.exception.StatusCode;
 import com.junior.page.PageCustom;
 import com.junior.security.WithMockCustomAdmin;
@@ -21,12 +22,12 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
 import static org.hamcrest.Matchers.nullValue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -107,6 +108,48 @@ public class ReportControllerTest extends BaseControllerTest {
                 .andExpect(jsonPath("$.data.pageable.number").value(1))
                 .andExpect(jsonPath("$.data.content[0].reportReason").value("스팸홍보"));
 
+
+    }
+
+    @Test
+    @DisplayName("신고 대상 스토리 상세 조회 - 응답이 반환되어야 함")
+    @WithMockCustomAdmin
+    public void findReportTargetStoryDetail() throws Exception {
+        //given
+        Long reportId = 1L;
+
+        AdminStoryDetailDto storyDetailDto = AdminStoryDetailDto.builder()
+                .id(1L)
+                .title("title")
+                .content("content")
+                .thumbnailImg("thumbnail")
+                .latitude(-10.0)
+                .longitude(10.0)
+                .city("서울")
+                .likeCnt(3L)
+                .createDate(LocalDateTime.of(2025, 1, 1, 0, 0, 0))
+                .imgUrls(new ArrayList<>())
+                .isDeleted(true)
+                .build();
+
+        given(reportService.findReportDetail(anyLong())).willReturn(storyDetailDto);
+
+        //when
+        ResultActions actions = mockMvc.perform(
+                get("/api/v1/admin/reports/{report_id}/stories", reportId)
+                        .accept(MediaType.APPLICATION_JSON)
+        );
+
+        //then
+        actions
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.customCode").value(StatusCode.REPORT_FIND_SUCCESS.getCustomCode()))
+                .andExpect(jsonPath("$.customMessage").value(StatusCode.REPORT_FIND_SUCCESS.getCustomMessage()))
+                .andExpect(jsonPath("$.status").value(true))
+                .andExpect(jsonPath("$.data.likeCnt").value(3L))
+                .andExpect(jsonPath("$.data.city").value("서울"))
+                .andExpect(jsonPath("$.data.isDeleted").value(true));
 
     }
 

--- a/module-api/src/test/java/com/junior/controller/report/ReportControllerTest.java
+++ b/module-api/src/test/java/com/junior/controller/report/ReportControllerTest.java
@@ -132,7 +132,7 @@ public class ReportControllerTest extends BaseControllerTest {
                 .isDeleted(true)
                 .build();
 
-        given(reportService.findReportDetail(anyLong())).willReturn(storyDetailDto);
+        given(reportService.findReportTargetStoryDetail(anyLong())).willReturn(storyDetailDto);
 
         //when
         ResultActions actions = mockMvc.perform(

--- a/module-api/src/test/java/com/junior/service/BaseServiceTest.java
+++ b/module-api/src/test/java/com/junior/service/BaseServiceTest.java
@@ -7,6 +7,7 @@ import com.junior.domain.member.MemberStatus;
 import com.junior.domain.member.SignUpType;
 import com.junior.domain.report.Report;
 import com.junior.domain.report.ReportReason;
+import com.junior.domain.report.ReportStatus;
 import com.junior.domain.report.ReportType;
 import com.junior.domain.story.Comment;
 import com.junior.domain.story.Story;
@@ -72,6 +73,16 @@ public class BaseServiceTest {
                 .member(member)
                 .reportType(reportType)
                 .reportReason(ReportReason.SPAMMARKET)
+                .story(story)
+                .build();
+    }
+
+    protected Report createReport(Member member, ReportType reportType, Story story, ReportStatus reportStatus) {
+        return Report.builder()
+                .member(member)
+                .reportType(reportType)
+                .reportReason(ReportReason.SPAMMARKET)
+                .reportStatus(reportStatus)
                 .story(story)
                 .build();
     }

--- a/module-api/src/test/java/com/junior/service/report/ReportServiceTest.java
+++ b/module-api/src/test/java/com/junior/service/report/ReportServiceTest.java
@@ -11,6 +11,7 @@ import com.junior.dto.report.CreateReportDto;
 import com.junior.dto.report.ReportDto;
 import com.junior.dto.report.ReportQueryDto;
 import com.junior.dto.report.StoryReportDto;
+import com.junior.dto.story.AdminStoryDetailDto;
 import com.junior.exception.NotValidMemberException;
 import com.junior.exception.ReportException;
 import com.junior.exception.StatusCode;
@@ -413,6 +414,44 @@ class ReportServiceTest extends BaseServiceTest {
                 .isInstanceOf(ReportException.class)
                 .hasMessageContaining(StatusCode.REPORT_TYPE_NOT_VALID.getCustomMessage());
 
+    }
+
+    @Test
+    @DisplayName("신고 대상 스토리 상세 조회 - 스토리 상세 조회 기능이 정상 동작해야 함")
+    void findReportTargetStoryDetail() {
+
+        //given
+        Member testActiveMember = createActiveTestMember();
+        Story testStory = createStory(testActiveMember, "title", "city");
+
+        Report testReport = createReport(testActiveMember, ReportType.STORY, testStory);
+
+        given(reportRepository.findById(anyLong())).willReturn(Optional.ofNullable(testReport));
+
+        //when
+        AdminStoryDetailDto result = reportService.findReportDetail(1L);
+
+        //then
+        assertThat(result.city()).isEqualTo("city");
+        assertThat(result.isDeleted()).isFalse();
+    }
+
+    @Test
+    @DisplayName("신고 대상 스토리 상세 조회 - 댓글 신고 내역에 대해 예외를 발생시켜야 함")
+    void failToFindReportTargetStoryDetailIfReportTypeIsComment() {
+
+        //given
+        Member testActiveMember = createActiveTestMember();
+        Story testStory = createStory(testActiveMember, "title", "city");
+        Comment testComment = createComment(testActiveMember, testStory);
+        Report testReport = createReport(testActiveMember, ReportType.COMMENT, testComment);
+
+        given(reportRepository.findById(anyLong())).willReturn(Optional.ofNullable(testReport));
+
+        //when
+        assertThatThrownBy(() -> reportService.findReportDetail(1L))
+                .isInstanceOf(ReportException.class)
+                .hasMessageContaining(StatusCode.REPORT_NOT_VALID.getCustomMessage());
     }
 
     @Test

--- a/module-api/src/test/java/com/junior/service/report/ReportServiceTest.java
+++ b/module-api/src/test/java/com/junior/service/report/ReportServiceTest.java
@@ -429,7 +429,7 @@ class ReportServiceTest extends BaseServiceTest {
         given(reportRepository.findById(anyLong())).willReturn(Optional.ofNullable(testReport));
 
         //when
-        AdminStoryDetailDto result = reportService.findReportDetail(1L);
+        AdminStoryDetailDto result = reportService.findReportTargetStoryDetail(1L);
 
         //then
         assertThat(result.city()).isEqualTo("city");
@@ -449,7 +449,7 @@ class ReportServiceTest extends BaseServiceTest {
         given(reportRepository.findById(anyLong())).willReturn(Optional.ofNullable(testReport));
 
         //when
-        assertThatThrownBy(() -> reportService.findReportDetail(1L))
+        assertThatThrownBy(() -> reportService.findReportTargetStoryDetail(1L))
                 .isInstanceOf(ReportException.class)
                 .hasMessageContaining(StatusCode.REPORT_NOT_VALID.getCustomMessage());
     }

--- a/module-api/src/test/java/com/junior/service/report/ReportServiceTest.java
+++ b/module-api/src/test/java/com/junior/service/report/ReportServiceTest.java
@@ -458,6 +458,98 @@ class ReportServiceTest extends BaseServiceTest {
     }
 
     @Test
+    @DisplayName("신고 처리 - 이미 처리된 신고일 경우 예외 처리를 해야 함")
+    void failToConfirmTargetIfReportAlreadyConfirmed() {
+
+        //given
+        Member testActiveMember = createActiveTestMember();
+        Story testStory = createStory(testActiveMember, "title", "city");
+
+        Report testReport = createReport(testActiveMember, ReportType.STORY, testStory, ReportStatus.CONFIRMED);
+
+
+        given(reportRepository.findById(anyLong())).willReturn(Optional.ofNullable(testReport));
+
+
+        //when, then
+        assertThatThrownBy(() -> reportService.confirmReport(1L))
+                .isInstanceOf(ReportException.class)
+                .hasMessageContaining(StatusCode.REPORT_ALREADY_CONFIRMED.getCustomMessage());
+
+
+    }
+
+    @Test
+    @DisplayName("신고 확인 - 이미 삭제 처리된 신고일 경우 예외 처리를 해야 함")
+    void failToConfirmReportIfReportAlreadyTargetDeleted() {
+
+        //given
+        Member testActiveMember = createActiveTestMember();
+        Story testStory = createStory(testActiveMember, "title", "city");
+
+        Report testReport = createReport(testActiveMember, ReportType.STORY, testStory, ReportStatus.DELETED);
+
+
+        given(reportRepository.findById(anyLong())).willReturn(Optional.ofNullable(testReport));
+
+
+        //when, then
+        assertThatThrownBy(() -> reportService.confirmReport(1L))
+                .isInstanceOf(ReportException.class)
+                .hasMessageContaining(StatusCode.REPORT_TARGET_ALREADY_DELETED.getCustomMessage());
+
+
+    }
+
+    @Test
+    @DisplayName("신고 확인 - 이미 삭제된 스토리를 처리하려 할 경우 예외 처리를 해야 함")
+    void failToConfirmReportIfReportTargetStoryAlreadyDeleted() {
+
+        //given
+        Member testActiveMember = createActiveTestMember();
+        Story testStory = createStory(testActiveMember, "title", "city");
+        testStory.deleteStory();
+
+        Report testReport = createReport(testActiveMember, ReportType.STORY, testStory);
+
+
+        given(reportRepository.findById(anyLong())).willReturn(Optional.ofNullable(testReport));
+
+
+        //when, then
+        assertThatThrownBy(() -> reportService.confirmReport(1L))
+                .isInstanceOf(ReportException.class)
+                .hasMessageContaining(StatusCode.REPORT_TARGET_ALREADY_DELETED.getCustomMessage());
+
+
+    }
+
+    @Test
+    @DisplayName("신고 확인 - 이미 삭제된 댓글을 처리하려 할 경우 예외 처리를 해야 함")
+    void failToConfirmReportIfReportTargetCommentAlreadyDeleted() {
+
+        //given
+        Member testActiveMember = createActiveTestMember();
+        Story testStory = createStory(testActiveMember, "title", "city");
+        Comment testComment = createComment(testActiveMember, testStory);
+
+        testComment.deleteComment();
+
+        Report testReport = createReport(testActiveMember, ReportType.COMMENT, testComment);
+
+
+        given(reportRepository.findById(anyLong())).willReturn(Optional.ofNullable(testReport));
+
+
+        //when, then
+        assertThatThrownBy(() -> reportService.confirmReport(1L))
+                .isInstanceOf(ReportException.class)
+                .hasMessageContaining(StatusCode.REPORT_TARGET_ALREADY_DELETED.getCustomMessage());
+
+
+    }
+
+    @Test
     @DisplayName("신고 대상 삭제 - 신고당한 스토리에 대한 삭제 처리가 정상적으로 이루어져야 함")
     void deleteStoryReport() {
 
@@ -501,6 +593,98 @@ class ReportServiceTest extends BaseServiceTest {
 
         assertThat(resultReport.getReportStatus()).isEqualTo(ReportStatus.DELETED);
         assertThat(resultReport.getComment().getIsDeleted()).isTrue();
+
+    }
+
+    @Test
+    @DisplayName("신고 대상 삭제 - 이미 처리된 신고일 경우 예외 처리를 해야 함")
+    void failToDeleteReportTargetIfReportAlreadyConfirmed() {
+
+        //given
+        Member testActiveMember = createActiveTestMember();
+        Story testStory = createStory(testActiveMember, "title", "city");
+
+        Report testReport = createReport(testActiveMember, ReportType.STORY, testStory, ReportStatus.CONFIRMED);
+
+
+        given(reportRepository.findById(anyLong())).willReturn(Optional.ofNullable(testReport));
+
+
+        //when, then
+        assertThatThrownBy(() -> reportService.deleteReportTarget(1L))
+                .isInstanceOf(ReportException.class)
+                .hasMessageContaining(StatusCode.REPORT_ALREADY_CONFIRMED.getCustomMessage());
+
+
+    }
+
+    @Test
+    @DisplayName("신고 대상 삭제 - 이미 삭제 처리된 신고일 경우 예외 처리를 해야 함")
+    void failToDeleteReportTargetIfReportAlreadyTargetDeleted() {
+
+        //given
+        Member testActiveMember = createActiveTestMember();
+        Story testStory = createStory(testActiveMember, "title", "city");
+
+        Report testReport = createReport(testActiveMember, ReportType.STORY, testStory, ReportStatus.DELETED);
+
+
+        given(reportRepository.findById(anyLong())).willReturn(Optional.ofNullable(testReport));
+
+
+        //when, then
+        assertThatThrownBy(() -> reportService.deleteReportTarget(1L))
+                .isInstanceOf(ReportException.class)
+                .hasMessageContaining(StatusCode.REPORT_TARGET_ALREADY_DELETED.getCustomMessage());
+
+
+    }
+
+    @Test
+    @DisplayName("신고 대상 삭제 - 이미 삭제된 스토리를 처리하려 할 경우 예외 처리를 해야 함")
+    void failToDeleteReportTargetIfReportTargetStoryAlreadyDeleted() {
+
+        //given
+        Member testActiveMember = createActiveTestMember();
+        Story testStory = createStory(testActiveMember, "title", "city");
+        testStory.deleteStory();
+
+        Report testReport = createReport(testActiveMember, ReportType.STORY, testStory);
+
+
+        given(reportRepository.findById(anyLong())).willReturn(Optional.ofNullable(testReport));
+
+
+        //when, then
+        assertThatThrownBy(() -> reportService.deleteReportTarget(1L))
+                .isInstanceOf(ReportException.class)
+                .hasMessageContaining(StatusCode.REPORT_TARGET_ALREADY_DELETED.getCustomMessage());
+
+
+    }
+
+    @Test
+    @DisplayName("신고 확인 - 이미 삭제된 댓글을 처리하려 할 경우 예외 처리를 해야 함")
+    void failToDeleteReportTargetIfReportTargetCommentAlreadyDeleted() {
+
+        //given
+        Member testActiveMember = createActiveTestMember();
+        Story testStory = createStory(testActiveMember, "title", "city");
+        Comment testComment = createComment(testActiveMember, testStory);
+
+        testComment.deleteComment();
+
+        Report testReport = createReport(testActiveMember, ReportType.COMMENT, testComment);
+
+
+        given(reportRepository.findById(anyLong())).willReturn(Optional.ofNullable(testReport));
+
+
+        //when, then
+        assertThatThrownBy(() -> reportService.deleteReportTarget(1L))
+                .isInstanceOf(ReportException.class)
+                .hasMessageContaining(StatusCode.REPORT_TARGET_ALREADY_DELETED.getCustomMessage());
+
 
     }
 

--- a/module-common/src/main/java/com/junior/exception/StatusCode.java
+++ b/module-common/src/main/java/com/junior/exception/StatusCode.java
@@ -134,6 +134,8 @@ public enum StatusCode {
     REPORT_TYPE_NOT_VALID(400, "REPORT-ERR-003", "서버 에러가 발생했습니다."),
     REPORT_EQUALS_AUTHOR(202, "REPORT-ERR-004", "본인 글은 신고가 불가능합니다."),
     REPORT_DUPLICATE(400, "REPORT-ERR-005", "이미 신고된 글 입니다."),
+    REPORT_ALREADY_CONFIRMED(400, "REPORT-ERR-006", "이미 확인 처리된 신고 내역입니다."),
+    REPORT_TARGET_ALREADY_DELETED(400, "REPORT-ERR-007", "이미 삭제 처리된 신고 내역입니다."),
 
     //버전 관리 관련 성공 코드
     VERSION_CREATE_SUCCESS(201, "VERSION-SUCCESS-001", ""),


### PR DESCRIPTION
- 신고 대상 글 삭제가 동작하지 않던 오류 수정
- 신고 처리를 중복으로 하는 경우 예외를 발생시키도록 수정
- 신고 대상 스토리 상세 조회 기능 구현
  - 스토리 상세 조회 + ReportStatus.CONFIRMED